### PR TITLE
Use Optional when returning IdentityProvider to make handling of it more robust to exceptions

### DIFF
--- a/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
+++ b/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
@@ -11,7 +11,7 @@ public interface SecurityConfig {
 
     CookieConfig getCookieConfig();
 
-    IdentityProvider createIdentityProvider();
+    Optional<IdentityProvider> createIdentityProvider();
 
     SocketAddress getBackend();
 

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
@@ -24,15 +24,15 @@ public class DefaultSecurityConfig implements SecurityConfig {
         this.IDP = idpConfigProvider.getByIdentifier(getIdp());
     }
 
-    public IdentityProvider createIdentityProvider() {
+    public Optional<IdentityProvider> createIdentityProvider() {
         try {
-            return (IdentityProvider) Class.forName(IDP.getIdpClass()).getConstructor(SecurityConfig.class).newInstance(this);
+            return Optional.of((IdentityProvider) Class.forName(IDP.getIdpClass()).getConstructor(SecurityConfig.class).newInstance(this));
         } catch (ClassNotFoundException exc) {
             exc.printStackTrace();
-            return null;
-        }  catch (Exception exc) { // so many possible exceptions for this
+            return Optional.empty();
+        } catch (Exception exc) { // so many possible exceptions for this
             exc.printStackTrace();
-            return null;
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
Bare en liten forandring i hvordan InboundHandler håndterer at det ikke finnes noen IdentityProvider for en sikret host.
