### PR TITLE
Cookie for original path in redirect

### DIFF
--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/CookieHandler.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/CookieHandler.java
@@ -1,9 +1,9 @@
 package no.difi.idporten.oidc.proxy.proxy;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
@@ -32,6 +32,7 @@ public class CookieHandler {
 
     /**
      * Instantiates a new CookieHandler based on some parameters from a HTTP request much like a SecurityConfig
+     *
      * @param cookieConfig
      * @param host
      * @param path
@@ -45,6 +46,7 @@ public class CookieHandler {
 
     /**
      * Generates a ProxyCookie using the CookieStorage which also saves it.
+     *
      * @param userData
      * @return
      */
@@ -54,6 +56,7 @@ public class CookieHandler {
 
     /**
      * Convenient function for getting a valid proxy cookie or an empty optional which eases the flow of InboundHandler.
+     *
      * @param httpRequest
      * @return
      */
@@ -99,10 +102,22 @@ public class CookieHandler {
     /**
      * Looks for a cookie with the name of this CookieHandler's cookieName in a request and returns a Netty cookie
      * object or an empty optional.
+     *
      * @param httpRequest
      * @return
      */
     private Optional<Cookie> getCookieFromRequest(HttpRequest httpRequest) {
+        return getCookieFromRequest(httpRequest, cookieName);
+    }
+
+    /**
+     * Looks for a cookie with the name of this CookieHandler's cookieName in a request and returns a Netty cookie
+     * object or an empty optional.
+     *
+     * @param httpRequest
+     * @return
+     */
+    public static Optional<Cookie> getCookieFromRequest(HttpRequest httpRequest, String cookieName) {
         if (httpRequest.headers().contains(HttpHeaderNames.COOKIE)) {
 
             String cookieString = httpRequest.headers().getAsString(HttpHeaderNames.COOKIE);
@@ -113,6 +128,18 @@ public class CookieHandler {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * A utility method that can be used by anyone.
+     *
+     * @param httpRequest
+     * @param cookieName
+     * @param cookieValue
+     */
+    public static void insertCookieToRequest(HttpRequest httpRequest, String cookieName, String cookieValue) {
+        httpRequest.headers().set(HttpHeaderNames.COOKIE, ClientCookieEncoder.STRICT.encode(cookieName, cookieValue));
+
     }
 
 }

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
@@ -94,7 +94,7 @@ public class InboundHandlerAdapter extends AbstractHandlerAdapter {
                             proxyCookie = cookieHandler.generateCookie(userData);
                             outboundChannel = responseGenerator.generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie);
                         } else {
-                            responseGenerator.generateRedirectResponse(ctx, idp, securityConfig);
+                            responseGenerator.generateRedirectResponse(ctx, idp, securityConfig, httpRequest.uri());
                         }
                     } else {
                         responseGenerator.generateDefaultResponse(ctx, host);

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
@@ -94,7 +94,7 @@ public class InboundHandlerAdapter extends AbstractHandlerAdapter {
                             proxyCookie = cookieHandler.generateCookie(userData);
                             outboundChannel = responseGenerator.generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie);
                         } else {
-                            responseGenerator.generateRedirectResponse(ctx, idp);
+                            responseGenerator.generateRedirectResponse(ctx, idp, securityConfig);
                         }
                     } else {
                         responseGenerator.generateDefaultResponse(ctx, host);

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandler.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandler.java
@@ -1,0 +1,57 @@
+package no.difi.idporten.oidc.proxy.proxy;
+
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import no.difi.idporten.oidc.proxy.model.CookieConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+public class RedirectCookieHandler {
+
+    private static Logger logger = LoggerFactory.getLogger(RedirectCookieHandler.class);
+
+    private final String cookieName;
+
+    private final String host;
+
+    private final String path;
+
+    private static HashMap<String, String> hashToPathMap = new HashMap<>();
+
+    /**
+     * Instantiates a new CookieHandler based on some parameters from a HTTP request much like a SecurityConfig
+     *
+     * @param cookieConfig
+     * @param host
+     * @param path
+     */
+    public RedirectCookieHandler(CookieConfig cookieConfig, String host, String path) {
+        this.cookieName = cookieConfig.getName();
+        this.host = host;
+        this.path = path;
+    }
+
+    public void insertCookieToResponse(HttpResponse response) {
+        String hash = generateCookieHash(path);
+        CookieHandler.insertCookieToResponse(response, "redirectCookie", hash);
+        hashToPathMap.put(hash, path);
+    }
+
+    private static String generateCookieHash(String path) {
+        return ("HASHASHASH" + path);
+    }
+
+    public static Optional<String> findRedirectCookiePath(HttpRequest request) {
+        if (hashToPathMap.containsKey(generateCookieHash(request.uri()))) {
+            String hashForRequest = generateCookieHash(request.uri());
+            String result = hashToPathMap.get(hashForRequest);
+            hashToPathMap.remove(hashForRequest);
+            return Optional.of(result);
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandlerTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandlerTest.java
@@ -1,6 +1,7 @@
 package no.difi.idporten.oidc.proxy.proxy;
 
 import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.cookie.Cookie;
 import no.difi.idporten.oidc.proxy.model.CookieConfig;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -33,7 +34,8 @@ public class RedirectCookieHandlerTest {
 
         Assert.assertFalse(RedirectCookieHandler.findRedirectCookiePath(httpRequest).isPresent());
 
-        redirectCookieHandler.insertCookieToResponse(httpResponse);
+        Cookie insertedCookie = redirectCookieHandler.insertCookieToResponse(httpResponse);
+        CookieHandler.insertCookieToRequest(httpRequest, insertedCookie.name(), insertedCookie.value());
 
         Optional<String> retrievedPathFromCookieOptional = RedirectCookieHandler.findRedirectCookiePath(httpRequest);
 

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandlerTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RedirectCookieHandlerTest.java
@@ -1,0 +1,46 @@
+package no.difi.idporten.oidc.proxy.proxy;
+
+import io.netty.handler.codec.http.*;
+import no.difi.idporten.oidc.proxy.model.CookieConfig;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+public class RedirectCookieHandlerTest {
+
+    private String host;
+    private String path;
+
+    @Mock
+    private CookieConfig cookieConfigMock;
+
+    @BeforeMethod
+    public void setUp() {
+        this.cookieConfigMock = Mockito.mock(CookieConfig.class);
+        this.host = "configured.host.com";
+        this.path = "/secured-path";
+    }
+
+    @Test
+    public void testCanInsertCookieToResponseAndItCanBeRetrievedAfter() {
+        RedirectCookieHandler redirectCookieHandler = new RedirectCookieHandler(cookieConfigMock, host, path);
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path);
+
+        Assert.assertFalse(RedirectCookieHandler.findRedirectCookiePath(httpRequest).isPresent());
+
+        redirectCookieHandler.insertCookieToResponse(httpResponse);
+
+        Optional<String> retrievedPathFromCookieOptional = RedirectCookieHandler.findRedirectCookiePath(httpRequest);
+
+        Assert.assertTrue(retrievedPathFromCookieOptional.isPresent());
+
+        String retrievedPathFromCookie = retrievedPathFromCookieOptional.get();
+
+        Assert.assertEquals(retrievedPathFromCookie, path);
+    }
+}

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
@@ -1,15 +1,9 @@
 package no.difi.idporten.oidc.proxy.proxy;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import no.difi.idporten.oidc.proxy.api.IdentityProvider;
-import no.difi.idporten.oidc.proxy.api.ProxyCookie;
-import no.difi.idporten.oidc.proxy.config.ConfigModule;
-import no.difi.idporten.oidc.proxy.lang.IdentityProviderException;
 import no.difi.idporten.oidc.proxy.model.CookieConfig;
-import no.difi.idporten.oidc.proxy.model.DefaultProxyCookie;
 import no.difi.idporten.oidc.proxy.model.SecurityConfig;
 import org.mockito.*;
 import org.slf4j.Logger;
@@ -18,8 +12,6 @@ import org.testng.Assert;
 import org.testng.annotations.*;
 
 import java.nio.charset.Charset;
-import java.util.Date;
-import java.util.HashMap;
 
 
 public class ResponseGeneratorTest {
@@ -103,13 +95,13 @@ public class ResponseGeneratorTest {
         ResponseGenerator responseGeneratorSpy = Mockito.spy(responseGenerator);
         // Because of exceptions we need to wrap tests in these ugly try/catch things
         try {
-            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock);
+            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock, securedPath);
         } catch (NullPointerException exc) {
 
         } finally {
             // All we need to test here is that the correct methods have been called and maybe which arguments
             // they were called with.
-            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any());
+            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
             Mockito.verify(identityProviderMock).generateRedirectURI();
 
             /* Not sure whether it's this method's responsibility to create an error when this goes south.
@@ -130,11 +122,11 @@ public class ResponseGeneratorTest {
         ResponseGenerator responseGeneratorSpy = Mockito.spy(responseGenerator);
         Mockito.doReturn(validRedirectUrl).when(identityProviderMock).generateRedirectURI();
         try {
-            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock);
+            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock, securedPath);
         } catch (NullPointerException exc) {
 
         } finally {
-            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any());
+            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
             Mockito.verify(identityProviderMock).generateRedirectURI();
             Mockito.atLeastOnce();
             Mockito.verify(ctxMock).writeAndFlush(httpResponseCaptor.capture());

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
@@ -167,46 +167,4 @@ public class ResponseGeneratorTest {
             Assert.assertTrue(content.contains(notConfiguredHostName));
         }
     }
-
-    @Test
-    public void generateJWTResponseWhenCorrectlyConfigured() throws Exception {
-        ResponseGenerator responseGeneratorSpy = Mockito.spy(responseGenerator);
-
-        String uuid = "uuid";
-        String cookieName = "TESTCOOKIE";
-        String path = "/beskyttet-side";
-        Date farFutureDate = new Date(new Date().getTime() + Integer.MAX_VALUE);
-
-        String pid = "08023549930";
-        HashMap<String, String> userData = new HashMap<>();
-        userData.put("pid", pid);
-        userData.put("tokenType", "JWTToken");
-        userData.put("aud", "dificamp");
-        ProxyCookie proxyCookie = new DefaultProxyCookie(uuid, cookieName, notConfiguredHostName, path, farFutureDate, farFutureDate,
-                userData);
-        try {
-            responseGeneratorSpy.generateJWTResponse(ctxMock, userData, proxyCookie);
-        } catch (NullPointerException exc) {
-
-        } catch (IdentityProviderException exc) {
-
-        } finally {
-            Mockito.verify(responseGeneratorSpy).generateJWTResponse(Mockito.any(), Mockito.any(), Mockito.any());
-            Mockito.verify(ctxMock).writeAndFlush(httpResponseCaptor.capture());
-
-            FullHttpResponse actual = httpResponseCaptor.getValue();
-            Assert.assertTrue(actual instanceof HttpResponse);
-            String content = actual.content().toString(Charset.forName("UTF-8"));
-            Assert.assertEquals(actual.status(), HttpResponseStatus.OK);
-            Assert.assertTrue(actual.headers().getAsString(HttpHeaderNames.CONTENT_TYPE).contains(ResponseGenerator
-                    .APPLICATION_JSON));
-            userData.entrySet().stream().forEach(entry -> {
-                Assert.assertTrue(content.contains(entry.getKey()));
-                Assert.assertTrue(content.contains(entry.getValue()));
-            });
-        }
-    }
-
-
-
 }

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/ResponseGeneratorTest.java
@@ -43,6 +43,8 @@ public class ResponseGeneratorTest {
      */
     @Mock
     private ChannelHandlerContext ctxMock;
+    @Mock
+    private SecurityConfig securityConfigMock;
 
 
     @BeforeTest
@@ -81,13 +83,13 @@ public class ResponseGeneratorTest {
         ResponseGenerator responseGeneratorSpy = Mockito.spy(responseGenerator);
         // Because of exceptions we need to wrap tests in these ugly try/catch things
         try {
-            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock);
+            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock);
         } catch (NullPointerException exc) {
 
         } finally {
             // All we need to test here is that the correct methods have been called and maybe which arguments
             // they were called with.
-            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any());
+            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any());
             Mockito.verify(identityProviderMock).generateRedirectURI();
 
             /* Not sure whether it's this method's responsibility to create an error when this goes south.
@@ -108,11 +110,11 @@ public class ResponseGeneratorTest {
         ResponseGenerator responseGeneratorSpy = Mockito.spy(responseGenerator);
         Mockito.doReturn(validRedirectUrl).when(identityProviderMock).generateRedirectURI();
         try {
-            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock);
+            responseGeneratorSpy.generateRedirectResponse(ctxMock, identityProviderMock, securityConfigMock);
         } catch (NullPointerException exc) {
 
         } finally {
-            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any());
+            Mockito.verify(responseGeneratorSpy).generateRedirectResponse(Mockito.any(), Mockito.any(), Mockito.any());
             Mockito.verify(identityProviderMock).generateRedirectURI();
             Mockito.atLeastOnce();
             Mockito.verify(ctxMock).writeAndFlush(httpResponseCaptor.capture());

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/SimpleIntegrationTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/SimpleIntegrationTest.java
@@ -202,7 +202,7 @@ public class SimpleIntegrationTest {
         //Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpStatus.SC_OK);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testFirstRedirectResponseHasCookieForSavingPath() throws Exception {
         logger.info("With a secured path on a configured host, the server should respond with a redirect " +
                 "response that has a Set-Cookie header in order to allow the server to remember the " +


### PR DESCRIPTION
Helt grunnleggende for at redirects skal ha en cookie og at man kan bruke den for å finne den originale pathen klienten ville til etter redirecten.

fixes #68 
