### PR TITLE
More integration tests

### DIFF
--- a/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/HostConfig.java
+++ b/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/HostConfig.java
@@ -15,4 +15,6 @@ public interface HostConfig {
     CookieConfig getCookieConfig();
 
     List<String> getUnsecuredPaths();
+
+    boolean isTotallyUnsecured(String path);
 }

--- a/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
+++ b/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
@@ -39,4 +39,12 @@ public interface SecurityConfig {
     List<String> getUnsecuredPaths();
 
     boolean isSecured();
+
+    /**
+     * Checks if the path is explicitly completely unsecured and should not receive the Difi headers.
+     *
+     * @param path
+     * @return
+     */
+    boolean isTotallyUnsecured(String path);
 }

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
@@ -86,6 +86,12 @@ public class DefaultSecurityConfig implements SecurityConfig {
         return HOST.getUnsecuredPaths();
     }
 
+
+    @Override
+    public boolean isTotallyUnsecured(String path) {
+        return HOST.isTotallyUnsecured(path);
+    }
+
     @Override
     public String getParameter(String key) {
         return IDP.getParameter(key).orElse("");

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
@@ -80,4 +80,9 @@ public class TypesafeHostConfig implements HostConfig {
     public List<String> getUnsecuredPaths() {
         return this.unsecuredPaths;
     }
+
+    @Override
+    public boolean isTotallyUnsecured(String path) {
+        return unsecuredPaths.stream().filter(path::startsWith).findFirst().isPresent();
+    }
 }

--- a/proxy-config/src/main/resources/reference.conf
+++ b/proxy-config/src/main/resources/reference.conf
@@ -122,7 +122,7 @@ host.mockhost = {
         idp: idporten
       },
     ]
-  unsecured_paths: []
+  unsecured_paths: ["/something/totally/unsecured"]
 }
 
 host.difi = {

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
@@ -121,7 +121,7 @@ public class ResponseGenerator {
         int connect_timeout_millis = 15000;
         int so_buf = 1048576;
 
-        if (proxyCookie != null && !checkForUnsecuredPaths(securityConfig.getUnsecuredPaths(), httpRequest.uri())) {
+        if (proxyCookie != null && !securityConfig.isTotallyUnsecured(httpRequest.uri())) {
             RequestInterceptor.insertUserDataToHeader(httpRequest, proxyCookie.getUserData(), securityConfig);
         }
 
@@ -190,7 +190,7 @@ public class ResponseGenerator {
      */
 
     private boolean checkForUnsecuredPaths(List<String> unsecuredPaths, String path) {
-        return unsecuredPaths.stream().filter(unsecuredPath -> unsecuredPath.startsWith(path)).findFirst().isPresent();
+        return unsecuredPaths.stream().filter(path::startsWith).findFirst().isPresent();
     }
 
 


### PR DESCRIPTION
Difi-headerne ble med på en request til en helt usikret ressurs, og tror feilen var med metoden for å sjekke om en path er totally unsecured. 

Lagde også en hjelpemetode i SecurityConfig for å sjekke om en path er helt usikret.
