### PR TITLE
Fix unsecured resource when logged in

### DIFF
--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
@@ -6,6 +6,7 @@ import no.difi.idporten.oidc.proxy.api.IdpConfigProvider;
 import no.difi.idporten.oidc.proxy.model.*;
 
 import java.net.SocketAddress;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -88,7 +89,11 @@ public class DefaultSecurityConfig implements SecurityConfig {
 
     @Override
     public List<String> getUserDataNames() {
-        return IDP.getUserDataNames();
+        if (IDP != null) {
+            return IDP.getUserDataNames();
+        } else {
+            return new LinkedList<>();
+        }
     }
 
     @Override
@@ -106,7 +111,6 @@ public class DefaultSecurityConfig implements SecurityConfig {
     public String getParameter(String key) {
         return IDP.getParameter(key).orElse("");
     }
-
 
 
     @Override

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
@@ -127,6 +127,7 @@ public class InboundHandlerAdapter extends AbstractHandlerAdapter {
             }
 
         } catch (Exception e) {
+            logger.error(e.getMessage(), e);
             responseGenerator.generateDefaultResponse(ctx, host);
         }
 

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/RequestInterceptor.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/RequestInterceptor.java
@@ -1,13 +1,10 @@
 package no.difi.idporten.oidc.proxy.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
-import no.difi.idporten.oidc.proxy.model.SecurityConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Utility class for manipulating HttpRequest
@@ -21,33 +18,13 @@ public class RequestInterceptor {
     public static final String HEADERNAME = "X-DifiProxy-";
 
     /**
-     *
      * @param httpRequest:
      * @param userData:
-     * @param securityConfig:
      */
-    public static void insertUserDataToHeader(HttpRequest httpRequest,
-                                              Map<String, String> userData, SecurityConfig securityConfig) {
-        List<String> userDataNames = securityConfig.getUserDataNames();
-
-        userDataNames.stream().forEach(userDataName -> {
-            httpRequest.headers().add(HEADERNAME + userDataName, encodeUserDataForHeader(userData, userDataName));
+    public static void insertUserDataToHeader(HttpRequest httpRequest, Map<String, String> userData) {
+        userData.entrySet().stream().forEach(userDataEntry -> {
+            httpRequest.headers().add(HEADERNAME + userDataEntry.getKey(), userDataEntry.getValue());
         });
         logger.debug("Inserted header to request:\n{}", httpRequest);
     }
-
-    /**
-     * Encodes a Map to a string in the standard format of HTTP headers.
-     * @param userData:
-     * @param userDataName:
-     * @return
-     */
-    private static String encodeUserDataForHeader(Map<String, String> userData, String userDataName) {
-        return userData.entrySet().stream()
-                .filter(entry -> userDataName.equals(entry.getKey()))
-                .map(entry -> String.format("%s", entry.getValue()))
-                .collect(Collectors.joining(""));
-    }
-
-
 }

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
@@ -98,7 +98,7 @@ public class ResponseGenerator {
         int so_buf = 1048576;
 
         if (proxyCookie != null && !securityConfig.isTotallyUnsecured(httpRequest.uri())) {
-            RequestInterceptor.insertUserDataToHeader(httpRequest, proxyCookie.getUserData(), securityConfig);
+            RequestInterceptor.insertUserDataToHeader(httpRequest, proxyCookie.getUserData());
         }
 
         Channel outboundChannel;

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/IntegrationTestWithMockServer.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/IntegrationTestWithMockServer.java
@@ -366,6 +366,21 @@ public class IntegrationTestWithMockServer {
         */
     }
 
+    @Test
+    public void testRequestingUnsecuredPathWithWhenLoggedInWithValidCookie() throws Exception {
+        HttpGet getRequest = getRequestWithValidGoogleCookie("/unsecured");
+
+        HttpResponse response = notFollowHttpClient.execute(getRequest);
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.code());
+        verify(1, getRequestedFor(urlPathEqualTo("/unsecured"))
+                .withHeader(RequestInterceptor.HEADERNAME + "email", matching(".*"))
+                .withHeader(RequestInterceptor.HEADERNAME + "email_verified", equalTo("true"))
+                .withHeader(RequestInterceptor.HEADERNAME + "sub", matching(".*"))
+        );
+
+    }
+
     private static HttpGet getRequestWithValidGoogleCookie(String path) throws Exception {
         String url = BASEURL + "/google";
         HttpGet getRequest = new HttpGet(url);

--- a/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RequestInterceptorTest.java
+++ b/proxy-proxy/src/test/java/no/difi/idporten/oidc/proxy/proxy/RequestInterceptorTest.java
@@ -46,8 +46,7 @@ public class RequestInterceptorTest {
     public void insertHeaderToRequest() {
         FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, host + path);
 
-        RequestInterceptor.insertUserDataToHeader(httpRequest, userData,
-                provider.getConfig("localhost:8080", "/idporten").get());
+        RequestInterceptor.insertUserDataToHeader(httpRequest, userData);
 
         HttpHeaders headers = httpRequest.headers();
 


### PR DESCRIPTION
The difi headers will be inserted into the request based on the UserData in the current cookie, and not what is configured for the current IDP.
This solves that the IDP for an unsecured path does not have any specific user data fields specified.
