### PR TITLE
Logout handling without logoutRedirectUri and passAlongData optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ host.hostname = {
         path: "/login_to_idporten"                             <!-- Root path of the secured area -->
         security: 2                                            <!-- Level of security -->
         idp: "idporten"                                        <!-- What identity provider should be used to log in on the secured area -->
-        redirect_uri: "redirect_uri"                           <!-- Optional in path -->
-        scope: "scope"                                         <!-- Optional in path -->
+        redirect_uri: "redirect_uri"                           <!-- Optional in path, obligatory in idp -->
+        scope: "scope"                                         <!-- Optional in path, obligatory in idp -->
       }
     ]
   preferred_idps: ["identity_provider1", "identity_provider2"] <!-- Preferred idps in descending order. A path's idp (if configured) will override this order, adding itself first -->
   logout_post_uri: "/logout"				                   <!-- The uri used to logout, triggering logout if user accesses url on host ending with this -->
-  logout_redirect_uri: "http://localhost:8080/logout-this"     <!-- Where the client is redirected back to when logging out -->
+  logout_redirect_uri: "http://localhost:8080/logout-this"     <!-- Optional. Where the client is redirected back to after removing cookie. Removes cookie and redirects to this address. Don't configure this if you want want your service to receive logout request on postUri with userData, just use postUri -->
   unsecured_paths: ["/unsecured_path1", "/unsecured_path2"]    <!-- Unsecured paths are paths that should not receive information about the user -->
 }
 ```
@@ -104,7 +104,7 @@ idp.identityProviderName = {
   password: "password"                                                     <!-- Password parameters used in the request towards the identity provider -->
   scope: "scope"                                                           <!-- The scope parameter used in the request towards the identity provider -->
   user_data_name: ["user_data_service_needs1", "user_data_service_needs2"] <!-- What user data collected from the log in should be sent to the service -->
-  pass_along_data: "identifying_data_for_idp"                              <!-- If a user is logged into multiple idps on a host, server returns userData of first preferred idp with cookie and this additional data from other idps with cookie -->
+  pass_along_data: "identifying_data_for_idp"                              <!-- Optional. If a user is logged into multiple idps on a host, server returns userData of first preferred idp with cookie and this additional data from other idps with cookie -->
   parameters: {                                                            <!-- Parameters have to be in the idp, but does not have to contain any parameters -->
     other_parameters: "like",                                              <!-- Other parameters need in the identity provider configuration -->
     security: 3
@@ -121,6 +121,7 @@ cookie.name = "global_cookie_name" <!-- Global name of the cookie the proxy uses
 cookie.touchPeriod = 20            <!-- How long the cookies validity should be expanded every time used -->
 cookie.maxExpiry = 60              <!-- How long the max expiry should be expanded every time used -->
 
+logoutHeader = "X-Logout"          <!-- Optional variable in case the server wants to terminate cookie without user interaction. Set response HTTP header 'logoutHeader: true' -->
 salt = "random_salt"               <!-- The salt is required globally in the conf-file -->
 ```
 
@@ -182,7 +183,7 @@ cookie.name = "proxy_cookie_name"
 cookie.touchPeriod = 30
 cookie.maxExpiry = 120
 
-
+logoutHeader = "X-Logout"
 salt = "2LMC539EF8nf04O9gndsfERGh3HI4ugjRTHnfAGmlwkSEhfnbi82finsdf"
 
 ```

--- a/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/HostConfig.java
+++ b/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/HostConfig.java
@@ -18,6 +18,8 @@ public interface HostConfig {
 
     String getSalt();
 
+    String getLogoutHeader();
+
     boolean isTotallyUnsecured(String path);
 
     String getLogoutRedirectUri();

--- a/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
+++ b/proxy-api/src/main/java/no/difi/idporten/oidc/proxy/model/SecurityConfig.java
@@ -43,6 +43,8 @@ public interface SecurityConfig {
 
     String getPassword();
 
+    String getLogoutHeader();
+
     String getSalt();
 
     List<String> getUserDataNames();

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/DefaultSecurityConfig.java
@@ -200,6 +200,11 @@ public class DefaultSecurityConfig implements SecurityConfig {
     }
 
     @Override
+    public String getLogoutHeader() {
+        return HOST.getLogoutHeader();
+    }
+
+    @Override
     public boolean isSecured() {
         return getSecurity() != 0;
     }

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
@@ -32,6 +32,8 @@ public class TypesafeHostConfig implements HostConfig {
 
     private CookieConfig cookieConfig;
 
+    private String logoutHeader;
+
     private String salt;
 
     private List<String> unsecuredPaths;
@@ -63,7 +65,11 @@ public class TypesafeHostConfig implements HostConfig {
 
         this.logoutPostUri = hostConfig.getString("logout_post_uri");
 
-        if (hostConfig.entrySet().toString().contains("logout_redirect_uri")){
+        if (hostConfig.entrySet().toString().contains("logoutHeader") || globalConfig.entrySet().toString().contains("logoutHeader")) {
+            this.logoutHeader = hostConfig.withFallback(globalConfig).getString("logoutHeader");
+        }
+
+        if (hostConfig.entrySet().toString().contains("logout_redirect_uri")) {
             this.logoutRedirectUri = hostConfig.getString("logout_redirect_uri");
         }
     }
@@ -122,5 +128,10 @@ public class TypesafeHostConfig implements HostConfig {
     @Override
     public List<String> getPreferredIdps() {
         return this.preferredIdps;
+    }
+
+    @Override
+    public String getLogoutHeader() {
+        return this.logoutHeader;
     }
 }

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeHostConfig.java
@@ -63,7 +63,9 @@ public class TypesafeHostConfig implements HostConfig {
 
         this.logoutPostUri = hostConfig.getString("logout_post_uri");
 
-        this.logoutRedirectUri = hostConfig.getString("logout_redirect_uri");
+        if (hostConfig.entrySet().toString().contains("logout_redirect_uri")){
+            this.logoutRedirectUri = hostConfig.getString("logout_redirect_uri");
+        }
     }
 
     @Override

--- a/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeIdpConfig.java
+++ b/proxy-config/src/main/java/no/difi/idporten/oidc/proxy/config/TypesafeIdpConfig.java
@@ -39,10 +39,14 @@ public class TypesafeIdpConfig implements IdpConfig {
         this.password = idpConfig.getString("password");
         this.scope = idpConfig.getString("scope");
         this.redirectUri = idpConfig.getString("redirect_uri");
-        this.passAlongData = idpConfig.getString("pass_along_data");
         this.userDataNames = idpConfig.getStringList("user_data_name");
         this.parameters = idpConfig.getConfig("parameters").entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().unwrapped().toString()));
+        if (idpConfig.entrySet().toString().contains("pass_along_data")) {
+            this.passAlongData = idpConfig.getString("pass_along_data");
+        } else {
+            this.passAlongData = "";
+        }
         logger.debug("Created IdpConfig:\n{}", this);
     }
 

--- a/proxy-config/src/test/resources/application.conf
+++ b/proxy-config/src/test/resources/application.conf
@@ -210,7 +210,7 @@ cookie.name = PROXYCOOKIE
 cookie.touchPeriod = 30
 cookie.maxExpiry = 120
 
-
+logoutHeader = "X-Logout"
 salt = 2LMC539EF8nf04O9gndsfERGh3HI4ugjRTHnfAGmlwkSEhfnbi82finsdf
 
 

--- a/proxy-config/src/test/resources/reference.conf
+++ b/proxy-config/src/test/resources/reference.conf
@@ -205,7 +205,7 @@ cookie.name = PROXYCOOKIE
 cookie.touchPeriod = 30
 cookie.maxExpiry = 120
 
-
+logoutHeader = "X-Logout"
 salt = 2LMC539EF8nf04O9gndsfERGh3HI4ugjRTHnfAGmlwkSEhfnbi82finsdf
 
 

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
@@ -67,10 +67,13 @@ public class InboundHandlerAdapter extends AbstractHandlerAdapter {
         } else if (proxyCookieOptional.isPresent()) {
             cookieHandler.removeCookie(proxyCookieOptional.get().getUuid());
             responseGenerator.generateLogoutProxyResponse(ctx, securityConfig, httpRequest, proxyCookieOptional.get());
-            logger.info("User logged out from all IDPs on host. Cookie deleted from browser and user sent proxyResponse on requested uri, given no configured logoutRedirectUri");
-        } else {
+            logger.info("User logged out from all IDPs on host. Cookie deleted from browser and user sent to requested uri, as no configured logoutRedirectUri exist");
+        } else if (hasSpecifiedLogoutRedirect){
             responseGenerator.generateLogoutRedirectResponse(ctx, securityConfig, null);
             logger.info("Logger requested log out without valid cookie present (likely already removed). Redirected to configured logoutRedirectUri ({})", securityConfig.getLogoutRedirectUri());
+        } else {
+            responseGenerator.generateLogoutProxyResponse(ctx, securityConfig, httpRequest);
+            logger.info("Logger requested log out without valid cookie present (likely already removed). User sent to requested uri, as no configured logoutRedirectUri exist");
         }
 
     }

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/InboundHandlerAdapter.java
@@ -68,7 +68,7 @@ public class InboundHandlerAdapter extends AbstractHandlerAdapter {
             cookieHandler.removeCookie(proxyCookieOptional.get().getUuid());
             responseGenerator.generateLogoutProxyResponse(ctx, securityConfig, httpRequest, proxyCookieOptional.get());
             logger.info("User logged out from all IDPs on host. Cookie deleted from browser and user sent to requested uri, as no configured logoutRedirectUri exist");
-        } else if (hasSpecifiedLogoutRedirect){
+        } else if (hasSpecifiedLogoutRedirect) {
             responseGenerator.generateLogoutRedirectResponse(ctx, securityConfig, null);
             logger.info("Logger requested log out without valid cookie present (likely already removed). Redirected to configured logoutRedirectUri ({})", securityConfig.getLogoutRedirectUri());
         } else {

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/OutboundInitializer.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/OutboundInitializer.java
@@ -4,16 +4,24 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
+import no.difi.idporten.oidc.proxy.model.ProxyCookie;
+import no.difi.idporten.oidc.proxy.model.SecurityConfig;
 
 public class OutboundInitializer extends ChannelInitializer<SocketChannel> {
 
     private Channel inbound;
 
+    private SecurityConfig securityConfig;
+
+    private ProxyCookie proxyCookie;
+
     private final boolean logout;
 
-    public OutboundInitializer(Channel inbound, boolean logout) {
+    public OutboundInitializer(Channel inbound, SecurityConfig securityConfig, ProxyCookie proxyCookie, boolean logout) {
         this.inbound = inbound;
+        this.securityConfig = securityConfig;
         this.logout = logout;
+        this.proxyCookie = proxyCookie;
     }
 
     @Override
@@ -21,7 +29,7 @@ public class OutboundInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline()
                 .addLast("codec", new HttpClientCodec(102400, 102400, 102400))
                 .addLast(new HttpResponseHandler())
-                .addLast(new OutboundHandlerAdapter(inbound, logout))
+                .addLast(new OutboundHandlerAdapter(inbound, securityConfig, proxyCookie, logout))
         ;
     }
 }

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/OutboundInitializer.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/OutboundInitializer.java
@@ -9,8 +9,11 @@ public class OutboundInitializer extends ChannelInitializer<SocketChannel> {
 
     private Channel inbound;
 
-    public OutboundInitializer(Channel inbound) {
+    private final boolean logout;
+
+    public OutboundInitializer(Channel inbound, boolean logout) {
         this.inbound = inbound;
+        this.logout = logout;
     }
 
     @Override
@@ -18,7 +21,7 @@ public class OutboundInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline()
                 .addLast("codec", new HttpClientCodec(102400, 102400, 102400))
                 .addLast(new HttpResponseHandler())
-                .addLast(new OutboundHandlerAdapter(inbound))
+                .addLast(new OutboundHandlerAdapter(inbound, logout))
         ;
     }
 }

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
@@ -9,6 +9,7 @@ import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import no.difi.idporten.oidc.proxy.api.IdentityProvider;
 import no.difi.idporten.oidc.proxy.lang.IdentityProviderException;
+import no.difi.idporten.oidc.proxy.model.CookieConfig;
 import no.difi.idporten.oidc.proxy.model.ProxyCookie;
 import no.difi.idporten.oidc.proxy.model.SecurityConfig;
 import org.slf4j.Logger;
@@ -63,26 +64,30 @@ public class ResponseGenerator {
         }
     }
 
-    protected void generateLogoutResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig,
-                                          String cookieName) {
-        logger.debug("ResponseGenerator.generateLogoutResponse()");
+    protected void generateLogoutProxyResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig,
+                                                       HttpRequest httpRequest, ProxyCookie proxyCookie) {
+            generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie.getUserData(), true);
+    }
+
+    protected void generateLogoutRedirectResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig,
+                                                                                   ProxyCookie proxyCookie) {
         try {
             String redirectUrl = securityConfig.getLogoutRedirectUri();
-            logger.debug("logoutRedirectUri: {}", redirectUrl);
 
             StringBuilder content = new StringBuilder(redirectUrl);
 
             FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                     HttpResponseStatus.FOUND, Unpooled.copiedBuffer(content, CharsetUtil.UTF_8));
 
-            CookieHandler.deleteCookieFromBrowser(cookieName, response);
+            if (proxyCookie != null) {
+                CookieHandler.deleteCookieFromBrowser(proxyCookie.getName(), response);
+            }
 
             response.headers().set(HttpHeaderNames.LOCATION, redirectUrl);
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             response.headers().set(HttpHeaderNames.CONTENT_TYPE, String.format(
                     "%s; %s=%s", HttpHeaderValues.TEXT_PLAIN, HttpHeaderValues.CHARSET, CharsetUtil.UTF_8));
 
-            logger.debug(String.format("Created logout response:\n%s", response));
             ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
 
         } catch (Exception e) {
@@ -90,6 +95,7 @@ public class ResponseGenerator {
             e.printStackTrace();
         }
     }
+
 
     /**
      * Generates a response when theres a problem with the server.
@@ -169,14 +175,13 @@ public class ResponseGenerator {
 
     public Channel generateProxyResponse(ChannelHandlerContext ctx, HttpRequest httpRequest,
                                          SecurityConfig securityConfig) {
-        return generateProxyResponse(ctx, httpRequest, securityConfig, new HashMap<>());
+        return generateProxyResponse(ctx, httpRequest, securityConfig, new HashMap<>(), false);
     }
 
     public Channel generateProxyResponse(ChannelHandlerContext ctx, HttpRequest httpRequest,
                                          SecurityConfig securityConfig, ProxyCookie proxyCookie) {
-        return generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie.getUserData());
+        return generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie.getUserData(), false);
     }
-
 
     /**
      * This is what happens when the proxy needs to work as a normal proxy.
@@ -189,7 +194,7 @@ public class ResponseGenerator {
      * @param userData:
      */
     public Channel generateProxyResponse(ChannelHandlerContext ctx, HttpRequest httpRequest,
-                                         SecurityConfig securityConfig, Map<String, String> userData) {
+                                         SecurityConfig securityConfig, Map<String, String> userData, boolean logout) {
         int connect_timeout_millis = 15000;
         int so_buf = 1048576;
 
@@ -202,7 +207,7 @@ public class ResponseGenerator {
 
         Bootstrap b = new Bootstrap();
         b.group(inboundChannel.eventLoop()).channel(ctx.channel().getClass());
-        b.handler(new OutboundInitializer(inboundChannel))
+        b.handler(new OutboundInitializer(inboundChannel, logout))
                 .option(ChannelOption.AUTO_READ, false);
 
         b.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
+++ b/proxy-proxy/src/main/java/no/difi/idporten/oidc/proxy/proxy/ResponseGenerator.java
@@ -64,13 +64,15 @@ public class ResponseGenerator {
         }
     }
 
-    protected void generateLogoutProxyResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig,
-                                                       HttpRequest httpRequest, ProxyCookie proxyCookie) {
-            generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie.getUserData(), true);
+    protected void generateLogoutProxyResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig, HttpRequest httpRequest) {
+        generateProxyResponse(ctx, httpRequest, securityConfig, null, true);
     }
 
-    protected void generateLogoutRedirectResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig,
-                                                                                   ProxyCookie proxyCookie) {
+    protected void generateLogoutProxyResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig, HttpRequest httpRequest, ProxyCookie proxyCookie) {
+        generateProxyResponse(ctx, httpRequest, securityConfig, proxyCookie.getUserData(), true);
+    }
+
+    protected void generateLogoutRedirectResponse(ChannelHandlerContext ctx, SecurityConfig securityConfig, ProxyCookie proxyCookie) {
         try {
             String redirectUrl = securityConfig.getLogoutRedirectUri();
 
@@ -175,7 +177,7 @@ public class ResponseGenerator {
 
     public Channel generateProxyResponse(ChannelHandlerContext ctx, HttpRequest httpRequest,
                                          SecurityConfig securityConfig) {
-        return generateProxyResponse(ctx, httpRequest, securityConfig, new HashMap<>(), false);
+        return generateProxyResponse(ctx, httpRequest, securityConfig, null, false);
     }
 
     public Channel generateProxyResponse(ChannelHandlerContext ctx, HttpRequest httpRequest,
@@ -198,8 +200,11 @@ public class ResponseGenerator {
         int connect_timeout_millis = 15000;
         int so_buf = 1048576;
 
-        RequestInterceptor.insertUserDataToHeader(httpRequest, userData, securityConfig);
-        logger.debug("UserData inserted to response: " + userData);
+        if (userData != null){
+            RequestInterceptor.insertUserDataToHeader(httpRequest, userData, securityConfig);
+            logger.debug("UserData inserted to header");
+        } else logger.debug("No userData to insert to header");
+
 
         Channel outboundChannel;
         logger.debug(String.format("Bootstrapping channel %s", ctx.channel()));

--- a/proxy-storage/src/main/java/no/difi/idporten/oidc/proxy/storage/DatabaseCookieStorage.java
+++ b/proxy-storage/src/main/java/no/difi/idporten/oidc/proxy/storage/DatabaseCookieStorage.java
@@ -107,7 +107,7 @@ public class DatabaseCookieStorage implements CookieStorage {
                             if (proxyCookie.getUserData() != null) userData.putAll(proxyCookie.getUserData());
                             primaryUserDataFound = true;
                             extendCookieExpiry(proxyCookie);
-                        } else if (cookieIdps.contains(preferredIdp.getKey()) && !userData.containsKey(preferredIdp.getKey())) {
+                        } else if (cookieIdps.contains(preferredIdp.getKey()) && !preferredIdp.getValue().isEmpty() && !userData.containsKey(preferredIdp.getKey())) {
                             logger.debug("Found cookie with idp ({}), but another idp was more preferable ", preferredIdp.getKey());
                             extendCookieExpiry(cookies.get(cookieIdps.indexOf(preferredIdp.getKey())));
                             String additionalData = cookies.get(cookieIdps.indexOf(preferredIdp.getKey())).getUserData().get(preferredIdp.getValue());


### PR DESCRIPTION
Handle logout where logoutRedirectUri is not present. Made passAlongData optional in configuration and made sure additional userData won't get added if not present.
